### PR TITLE
Adding equals and hashCode to domain specific values

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@ Roperty
 
 Roperty - An advanced property management and retrival system
 
-Roperty is roughly a hierarchical id-value-store. All keys accessed are cached in memory.
+Roperty is roughly a hierarchical key-value-store. All keys accessed are cached in memory.
 Depending of the persistence implementation, all keys are also preloaded into memory upon startup.
-The main task for Roperty is to serve values to a id according to a domain hierarchy.
+The main task for Roperty is to serve values to a key according to a domain hierarchy.
 
 Domain hierarchies can be freely defined. As an example, a possible hierarchy for translation could be something like:
 
     Language | Country | Partner | A/B-Testgroup
 
-When a id is accessed from Roperty, a DomainResolver needs to be provided.
+When a key is accessed from Roperty, a DomainResolver needs to be provided.
 
 ```java
 DomainResolver domainResolver = ....;
@@ -53,7 +53,7 @@ So for example, there might be the following values stored in Roperty for "keyTo
 
 Accessing this Roperty instance with the given domainResolver would return "Spezielle Übersetzung für Deutschland".
 
-In addition Roperty also supports wildcards for domain keys. For example I could add a id translation like:
+In addition Roperty also supports wildcards for domain keys. For example I could add a key translation like:
 
     de|*|google| => Deutscher Text für Google Partner Konto
     *|*|google| => Special translation for google partner account

--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@ Roperty
 
 Roperty - An advanced property management and retrival system
 
-Roperty is roughly a hierarchical key-value-store. All keys accessed are cached in memory.
+Roperty is roughly a hierarchical id-value-store. All keys accessed are cached in memory.
 Depending of the persistence implementation, all keys are also preloaded into memory upon startup.
-The main task for Roperty is to serve values to a key according to a domain hierarchy.
+The main task for Roperty is to serve values to a id according to a domain hierarchy.
 
 Domain hierarchies can be freely defined. As an example, a possible hierarchy for translation could be something like:
 
     Language | Country | Partner | A/B-Testgroup
 
-When a key is accessed from Roperty, a DomainResolver needs to be provided.
+When a id is accessed from Roperty, a DomainResolver needs to be provided.
 
 ```java
 DomainResolver domainResolver = ....;
@@ -53,7 +53,7 @@ So for example, there might be the following values stored in Roperty for "keyTo
 
 Accessing this Roperty instance with the given domainResolver would return "Spezielle Übersetzung für Deutschland".
 
-In addition Roperty also supports wildcards for domain keys. For example I could add a key translation like:
+In addition Roperty also supports wildcards for domain keys. For example I could add a id translation like:
 
     de|*|google| => Deutscher Text für Google Partner Konto
     *|*|google| => Special translation for google partner account

--- a/src/main/java/com/parship/roperty/DomainSpecificValue.java
+++ b/src/main/java/com/parship/roperty/DomainSpecificValue.java
@@ -85,6 +85,29 @@ public class DomainSpecificValue implements Comparable<DomainSpecificValue> {
 	}
 
 	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		DomainSpecificValue that = (DomainSpecificValue) o;
+
+		if (ordering != that.ordering) return false;
+		if (!patternStr.equals(that.patternStr)) return false;
+		if (!value.equals(that.value)) return false;
+		return changeSet != null ? changeSet.equals(that.changeSet) : that.changeSet == null;
+
+	}
+
+	@Override
+	public int hashCode() {
+		int result = patternStr.hashCode();
+		result = 31 * result + ordering;
+		result = 31 * result + value.hashCode();
+		result = 31 * result + (changeSet != null ? changeSet.hashCode() : 0);
+		return result;
+	}
+
+	@Override
 	public String toString() {
 		return "DomainSpecificValue{" +
 			"pattern=\"" + patternStr +

--- a/src/main/java/com/parship/roperty/KeyValues.java
+++ b/src/main/java/com/parship/roperty/KeyValues.java
@@ -51,6 +51,7 @@ public class KeyValues {
 	}
 
 	public DomainSpecificValue putWithChangeSet(final String changeSet, final Object value, final String... domainKeyParts) {
+		Objects.requireNonNull(domainKeyParts, "Domain key parts may no be null");
 		for (String domain : domainKeyParts) {
 			Ensure.notEmpty(domain, "domain");
 		}
@@ -72,7 +73,6 @@ public class KeyValues {
 		return domainSpecificValue;
 	}
 
-	@SuppressWarnings("unchecked")
 	public <T> T get(Iterable<String> domains, T defaultValue, final DomainResolver resolver) {
         Objects.requireNonNull(domains, "\"domains\" must not be null");
         String domainStr = buildDomain(domains, resolver);


### PR DESCRIPTION
To be able to compar domain specific values in a persistence implementation (e.g. to compare to sets), a hashCode and a equals method is required. Please mind merging these changes.