### PR TITLE
Change set should be stored as null in persistence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<prerequisites>
 		<maven>3.0.4</maven>
@@ -8,7 +9,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.parship</groupId>
 	<artifactId>roperty</artifactId>
-	<version>0.13-SNAPSHOT</version>
+	<version>0.12-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>Roperty</name>
 	<description>Roperty - An advanced property management and retrieval system with hierarchical resolution of values</description>
@@ -25,8 +26,7 @@
 		<url>git@github.com:parship/roperty.git</url>
 		<connection>scm:git:git@github.com:parship/roperty.git</connection>
 		<developerConnection>scm:git:git@github.com:parship/roperty.git</developerConnection>
-	  <tag>HEAD</tag>
-  </scm>
+	</scm>
 
 	<developers>
 		<developer>

--- a/src/main/java/com/parship/roperty/RopertyImpl.java
+++ b/src/main/java/com/parship/roperty/RopertyImpl.java
@@ -212,7 +212,7 @@ public class RopertyImpl implements Roperty {
 
 	private void store(final String key, final KeyValues keyValues) {
 		if (persistence != null) {
-			persistence.store(key, keyValues, "");
+			persistence.store(key, keyValues, null);
 		}
 	}
 

--- a/src/main/java/com/parship/roperty/ValuesStore.java
+++ b/src/main/java/com/parship/roperty/ValuesStore.java
@@ -4,6 +4,7 @@ import java.io.PrintStream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class ValuesStore {
 
@@ -17,6 +18,7 @@ public class ValuesStore {
     }
 
     public void setAllValues(Map<? extends String, ? extends KeyValues> values) {
+        Objects.requireNonNull(values, "Values must not be null");
         keyValuesMap.clear();
         keyValuesMap.putAll(values);
     }

--- a/src/test/java/com/parship/roperty/RopertyImplTest.java
+++ b/src/test/java/com/parship/roperty/RopertyImplTest.java
@@ -166,7 +166,7 @@ public class RopertyImplTest {
 		KeyValues keyValue = new KeyValues(new DefaultDomainSpecificValueFactory());
 		when(persistenceMock.load(eq(key), any(KeyValuesFactory.class), any(DomainSpecificValueFactory.class))).thenReturn(keyValue);
 		ropertyWithResolver.set(key, "value", null);
-		verify(persistenceMock).store(key, keyValue, "");
+		verify(persistenceMock).store(key, keyValue, null);
 	}
 
 	@Test


### PR DESCRIPTION
While implementing a persistence for Roperty, I stumbled across a value, that had an empty string as change set. I stored it by using Roperty's set method without a change set. Later when getting the domain specific value, it couldn't be found, because its changeset was not null, but an empty string. Fixed this by using null when storing a value without a change set. Now it is consistent.