### PR TITLE
Removed redundant null check before Objects.equals and synchronized modifier

### DIFF
--- a/src/main/java/com/parship/roperty/DomainSpecificValue.java
+++ b/src/main/java/com/parship/roperty/DomainSpecificValue.java
@@ -143,7 +143,6 @@ public class DomainSpecificValue implements Comparable<DomainSpecificValue> {
     }
 
 	public boolean changeSetIs(final String changeSet) {
-		return ((this.changeSet == null && changeSet == null)
-			|| (Objects.equals(this.changeSet, changeSet)));
+		return Objects.equals(this.changeSet, changeSet);
 	}
 }

--- a/src/main/java/com/parship/roperty/KeyValues.java
+++ b/src/main/java/com/parship/roperty/KeyValues.java
@@ -58,7 +58,7 @@ public class KeyValues {
 		return addOrChangeDomainSpecificValue(changeSet, value, domainKeyParts);
 	}
 
-	private synchronized DomainSpecificValue addOrChangeDomainSpecificValue(final String changeSet, final Object value, final String[] domainKeyParts) {
+	private DomainSpecificValue addOrChangeDomainSpecificValue(final String changeSet, final Object value, final String[] domainKeyParts) {
 		DomainSpecificValue domainSpecificValue = domainSpecificValueFactory.create(value, changeSet, domainKeyParts);
 
 		if (domainSpecificValues.contains(domainSpecificValue)) {


### PR DESCRIPTION
The synchronized modifier given in class KeyValues on method addOrChangeDomainSpecificValue is not needed, because the ConcurrentSkipList is already thread safe.

The method changeSetIs does some redundant null checks, that will be done by Objects.equals