### PR TITLE
Resolve 2 mismatch stubbings in KeyValueTest.java

### DIFF
--- a/src/test/java/com/parship/roperty/KeyValuesTest.java
+++ b/src/test/java/com/parship/roperty/KeyValuesTest.java
@@ -128,6 +128,8 @@ public class KeyValuesTest {
 	@Test
 	public void wildcardsAlsoMatchNullDomainValues() {
 		DomainResolver resolverMock = mock(DomainResolver.class);
+        when(resolverMock.getDomainValue("dom1")).thenReturn(null);
+        when(resolverMock.getDomainValue("dom2")).thenReturn(null);
 		when(resolverMock.getDomainValue("dom3")).thenReturn("domVal3");
 		keyValues.put("value", "*", "*", "domVal3");
 		assertThat(keyValues.get(asList("dom1", "dom2", "dom3"), "default", resolverMock), is("value"));


### PR DESCRIPTION
We are researchers and analyzed the test doubles (mocks) in the test code of the project. In our analysis of the project, we observed that

+ The `getDominValue` method, which is previously stubbed, is executed with arguments "dom1" and "dom2", but these specific arguments are not stubbed, resulting in mismatch stubbings. These mismatches occur in the test `wildcardsAlsoMatchNullDomainValues`.

In this pull request, we propose a solution to resolve the mismatch stubbing.

Mismatched stubbing occurs when a mocked method is stubbed with specific arguments in a test but later invoked with different arguments in the code, potentially causing unexpected behavior. Mockito recommends addressing these issues, (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/PotentialStubbingProblem.html)